### PR TITLE
Improve segmentation of characters like i, j and :

### DIFF
--- a/WLC/image_processing/extended_image.py
+++ b/WLC/image_processing/extended_image.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import sys
 
 import cv2
 import numpy as np
@@ -47,21 +48,32 @@ class ExtendedImage:
         used_contours = []
 
         for ctr in sorted_ctrs:
-            M = cv2.moments(ctr)
+            point = self._get_center_of_contour(ctr)
 
-            if M["m00"]:
-                cX = int((M["m10"] / M["m00"]))
-                cY = int(M["m01"] / M["m00"])
-                points.append((cX, cY))
+            if point:
+                points.append(point)
                 used_contours.append(ctr)
 
         return points, used_contours
+
+    def _get_center_of_contour(self, ctr):
+        moment = cv2.moments(ctr)
+
+        if moment["m00"]:
+            cX = int((moment["m10"] / moment["m00"]))
+            cY = int(moment["m01"] / moment["m00"])
+            return cX, cY
+
+        return None
 
     def _find_contours(self, img):
         im2, ctrs, hier = cv2.findContours(img.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
         return sorted(ctrs, key=lambda ctr: cv2.boundingRect(ctr)[0])
 
     def average_node_distance(self, nodes):
+        if len(nodes) < 2:
+            return 0, 0
+
         distances = [math.sqrt(self.closest_node(n, nodes)) for n in nodes]
         return np.mean(distances), np.std(distances)
 

--- a/WLC/image_processing/extended_image.py
+++ b/WLC/image_processing/extended_image.py
@@ -60,8 +60,8 @@ class ExtendedImage:
         moment = cv2.moments(ctr)
 
         if moment["m00"]:
-            cX = int((moment["m10"] / moment["m00"]))
-            cY = int(moment["m01"] / moment["m00"])
+            cX = moment["m10"] // moment["m00"]
+            cY = moment["m01"] // moment["m00"]
             return cX, cY
 
         return None

--- a/WLC/image_processing/line.py
+++ b/WLC/image_processing/line.py
@@ -56,7 +56,7 @@ class Line(ExtendedImage):
                 min_y, max_y = self._truncate_black_borders(roi)
                 roi = roi[min_y:max_y]
 
-                words.append(Word(roi, x_axis, y_axis, width, max_y - min_y, self.preferences))
+                words.append(Word(roi, x_axis, y_axis, width, max_y - min_y, average_distance, self.preferences))
                 previous_x = x_axis
 
         LOGGER.debug("%d words detected in this line.", len(words))

--- a/WLC/ocr/ocr.py
+++ b/WLC/ocr/ocr.py
@@ -13,6 +13,7 @@ environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 MINIMUM_PROBABILITY = 0.01
 
+
 class OCR(metaclass=Singleton):
 
     def __init__(self):


### PR DESCRIPTION
Given that i is made of two separate parts it has to be merged into one, previously merging was done based on the distance from the left hand corner of the character. This is an issue with  j because the left hand corner is far from the center. Now it uses the center of the character instead.